### PR TITLE
fix api url for config; caused auth to be dysfunctional

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ module.exports = {
     webpack5: true,
   },
   env: {
-    NEXT_PUBLIC_API_URL: 'http://localhost:8080',
+    NEXT_PUBLIC_API_URL: 'https://api.pomodomo.ca',
     // localhost:8080
   },
 };


### PR DESCRIPTION
Changed https://api.pomodomo.ca/ to https://api.pomodomo.ca which caused auth to be useless